### PR TITLE
SS-8748: Avoid recording useless save actions

### DIFF
--- a/src/Listener/Form/Submission.php
+++ b/src/Listener/Form/Submission.php
@@ -140,6 +140,11 @@ class Submission extends Extension
             return;
         }
 
+        // avoid recording useless save actions to prevent multiple snapshots of the same version
+        if ($form->getName() === 'EditForm' && $action === 'save' && !$page->isModifiedOnDraft()) {
+            return;
+        }
+
         // attempt to create a custom snapshot first
         $customSnapshot = $snapshot->formSubmissionSnapshot($form, $request, $page, $action, $message);
 


### PR DESCRIPTION
prevents recording a snapshot when a save action has no effect