### PR TITLE
Bugfix/no modification snapshots

### DIFF
--- a/src/Listener/Form/Submission.php
+++ b/src/Listener/Form/Submission.php
@@ -148,6 +148,14 @@ class Submission extends Extension
         }
 
         // fall back to default snapshot
-        $snapshot->createSnapshotFromAction($page, $record, $message);
+        $snapshotInstance = $snapshot->createSnapshotFromAction($page, $record, $message);
+
+        // mark publish actions as WasPublished - the status flags rely on this being set correctly
+        if ($form->getName() === 'EditForm' && $action === 'publish') {
+            foreach ($snapshotInstance->Items() as $item) {
+                $item->WasPublished = true;
+                $item->write();
+            }
+        }
     }
 }

--- a/src/SnapshotItem.php
+++ b/src/SnapshotItem.php
@@ -44,6 +44,7 @@ class SnapshotItem extends DataObject
         'WasDraft' => 'Boolean',
         'WasDeleted' => 'Boolean',
         'ObjectHash' => 'Varchar(64)',
+        'Modification' => 'Boolean', // indicates the snapshot item changes data (default true)
     ];
 
     /**
@@ -66,6 +67,13 @@ class SnapshotItem extends DataObject
             'type' => 'unique',
             'columns' => ['ObjectHash', 'Version', 'SnapshotID']
         ]
+    ];
+
+    /**
+     * @var array
+     */
+    private static $defaults = [
+        'Modification' => true,
     ];
 
     /**


### PR DESCRIPTION
Some snapshot items can be information-only so don't require a publish at the owner.
These items will be excluded from status flag checks

Also, the listener mode was not marking publish form submissions as 'WasPublished' this adds that back so that the status flags won't incorrectly show a published page as modified. 